### PR TITLE
set daemon=True on threads

### DIFF
--- a/threads.py
+++ b/threads.py
@@ -1,4 +1,4 @@
-import consensus, listener, threading, custom, blockchain, leveldb, gui, networking
+import consensus, listener, threading, custom, blockchain, leveldb, gui, networking, time
 
 db=leveldb.LevelDB(custom.database_name)
 DB={'db':db, 
@@ -16,14 +16,17 @@ todo=[
 #keeps track of blockchain database, checks on peers for new 
 #blocks and transactions.
     [consensus.mainloop, 
-     (custom.pubkey, custom.peers, custom.hashes_per_check, DB), False],
+     (custom.pubkey, custom.peers, custom.hashes_per_check, DB), True],
 #listens for peers. Peers might ask us for our blocks and our pool of recent 
 #transactions, or peers could suggest blocks and transactions to us.
-      [listener.server, (DB, ), False],
-      [gui.main, (custom.gui_port, custom.brainwallet, DB), False]]
+      [listener.server, (DB, ), True],
+      [gui.main, (custom.gui_port, custom.brainwallet, DB), True]]
 networking.kill_processes_using_ports([str(custom.gui_port),
                                        str(custom.listen_port)])
 for i in todo:
     t = threading.Thread(target=i[0], args = i[1])
     t.setDaemon(i[2])
     t.start()
+
+while True:
+    time.sleep(1)


### PR DESCRIPTION
I'm not sure if there was a reason the threads had daemon set to false, but I think users should be able to stop all threads with ctrl-c. This is a simple way of doing that (with an infinite loop in the main thread).
